### PR TITLE
[BE] 일정 목록 조회 API 일정에 포함된 장소 개수 추가

### DIFF
--- a/BE/newsainturtle/src/main/java/com/newsainturtle/user/dto/ScheduleListResponse.java
+++ b/BE/newsainturtle/src/main/java/com/newsainturtle/user/dto/ScheduleListResponse.java
@@ -19,6 +19,7 @@ public class ScheduleListResponse {
     private String schedule_name;
     private String start_day;
     private String end_day;
+    private int locationCount;
     private LocalDateTime modifiedTime;
     private boolean isPrivate;
     private boolean isMine;
@@ -33,6 +34,7 @@ public class ScheduleListResponse {
                 .regionId(value.getRegionId())
                 .schedule_name(value.getScheduleName())
                 .start_day(value.getScheduleStartDay())
+                .locationCount(value.getScheduleLocations().size())
                 .end_day(value.getScheduleEndDay())
                 .modifiedTime(value.getModifiedTime())
                 .isPrivate(value.isPrivate())


### PR DESCRIPTION
일정 목록 조회시 일정에 포함된 장소 수 정보 추가

close #302 

## 어떤 이유로 MR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 일정 목록 조회 시 일정에 포함된 장소 수 정보 추가

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
